### PR TITLE
Added more flexibility to port usage, base URL configuration and updated README

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,7 @@ end_of_line = lf
 insert_final_newline = true
 indent_style = space
 trim_trailing_whitespace = true
-indent_size = 4
+indent_size = 8
 
 [*.go]
 indent_size = 8
@@ -20,4 +20,4 @@ indent_style = tab
 trim_trailing_whitespace = false
 
 [*.{html,css,js}]
-indent_size = 2
+indent_size = 8

--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,7 @@ end_of_line = lf
 insert_final_newline = true
 indent_style = space
 trim_trailing_whitespace = true
-indent_size = 8
+indent_size = 4
 
 [*.go]
 indent_size = 8
@@ -20,4 +20,4 @@ indent_style = tab
 trim_trailing_whitespace = false
 
 [*.{html,css,js}]
-indent_size = 8
+indent_size = 2

--- a/README.md
+++ b/README.md
@@ -21,12 +21,18 @@ For more information, see [seashells.io](https://seashells.io) or the [launch bl
 
 ### Environment Variables
 
-- `NETCAT_BINDING`: interface/port to listen for terminal connections. Defaults to `:1337`. 📝 This should be directly accessible to the network/internet. 
-- `WEBAPP_BINDING`: interface/port to listen for web app connections. Defaults to `:8080`. 📝 _Strongly_ consider using `127.0.0.1:port` and using a secure reverse proxy.
-- `BASE_URL`: URL prefix to print out with randomized connection path string when terminal connections are established. Defaults to `https://seashells.io/v/`. 📝 You will almost certainly want to change this.
-- `GIN_MODE`: [Gin web framework](https://gin-gonic.com/) mode (`debug` or `release`). Defaults to `debug`.
-- `GTAG`: Header tag to pass along with requests. Defaults to `g-tag`. # 🚨 CHANGE THIS!
-- `ADMIN_PASSWORD`: Password to use for all admin actions. Defaults to `xxx`. # 🚨 CHANGE THIS!
+- `NETCAT_BINDING`: interface/port to listen for terminal connections.  
+  Defaults to `:1337`. 📝 This should be directly accessible to the network/internet.
+- `WEBAPP_BINDING`: interface/port to listen for web app connections.  
+  Defaults to `:8080`. 📝 _Strongly_ consider using `127.0.0.1:port` and using a secure reverse proxy.
+- `BASE_URL`: URL prefix to print out with randomized connection path string when terminal connections are established.  
+  Defaults to `https://seashells.io/v/`. 📝 You will almost certainly want to change this.  
+- `GIN_MODE`: [Gin web framework](https://gin-gonic.com/) mode (`debug` or `release`).  
+  Defaults to `debug`.
+- `GTAG`: Header tag to pass along with requests.  
+  Defaults to `g-tag`. # 🚨 CHANGE THIS!
+- `ADMIN_PASSWORD`: Password to use for all admin actions.  
+  Defaults to `xxx`. # 🚨 CHANGE THIS!
 
 ### Paths
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,21 @@ For more information, see [seashells.io](https://seashells.io) or the [launch bl
 2. Configure some settings, by `cp env.sample env` and editing the resulting `env` file
 3. Run with `./run.bash`
 
+### Environment Variables
+
+- `NETCAT_BINDING`: interface/port to listen for terminal connections. Defaults to `:1337`. 📝 This should be directly accessible to the network/internet. 
+- `WEBAPP_BINDING`: interface/port to listen for web app connections. Defaults to `:8080`. 📝 _Strongly_ consider using `127.0.0.1:port` and using a secure reverse proxy.
+- `BASE_URL`: URL prefix to print out with randomized connection path string when terminal connections are established. Defaults to `https://seashells.io/v/`. 📝 You will almost certainly want to change this.
+- `GIN_MODE`: [Gin web framework](https://gin-gonic.com/) mode (`debug` or `release`). Defaults to `debug`.
+- `GTAG`: Header tag to pass along with requests. Defaults to `g-tag`. # 🚨 CHANGE THIS!
+- `ADMIN_PASSWORD`: Password to use for all admin actions. Defaults to `xxx`. # 🚨 CHANGE THIS!
+
+### Paths
+
+- `/v/:id` the default endpoint provided after establishing a terminal session (full xterm.js terminal emulation)
+- `/p/:id` plaintext version of ^^
+- `/inspect` admin login endpoint to see an overview of sessions username is `admin` and password is in `ADMIN_PASSWORD` env var
+
 ## License
 
 Copyright (c) Anish Athalye. Released under AGPLv3. See [LICENSE.txt](LICENSE.txt) for details.

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,10 @@
+package config
+
+type Config struct {
+	GinMode       string `env:"GIN_MODE" envDefault:"debug"`
+	AdminPassword string `env:"ADMIN_PASSWORD" envDefault:"xxx"`
+	Gtag          string `env:"GTAG" envDefault:"g-tag"`
+	BaseURL       string `env:"BASE_URL" envDefault:"https://seashells.io/v/"`
+	NetCatBinding string `env:"NETCAT_BINDING" envDefault:":1337"`
+	WebAppBinding string `env:"WEBAPP_BINDING" envDefault:":8080"`
+}

--- a/env.sample
+++ b/env.sample
@@ -1,4 +1,7 @@
-export PORT='8888'
-export GIN_MODE='release'
+#!/bin/bash
+export BASE_URL='https://seashells.io/v/'
+export WEBAPP_BINDING=':8080'
+export NETCAT_BINDING=':1337'
 export ADMIN_PASSWORD='xxx'
-export GTAG='xxx'
+export GIN_MODE='debug'
+export GTAG='g-tag'

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/anishathalye/seashells-server
 go 1.13
 
 require (
+	github.com/caarlos0/env v3.5.0+incompatible // indirect
 	github.com/gin-gonic/gin v1.8.2
 	github.com/gorilla/websocket v1.5.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/caarlos0/env v3.5.0+incompatible h1:Yy0UN8o9Wtr/jGHZDpCBLpNrzcFLLM2yixi/rBrKyJs=
+github.com/caarlos0/env v3.5.0+incompatible/go.mod h1:tdCsowwCzMLdkqRYDlHpZCp2UooDD3MspDBjZ2AD02Y=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/main.go
+++ b/main.go
@@ -1,12 +1,15 @@
 package main
 
 import (
-	"github.com/anishathalye/seashells-server/datamanager"
+	"fmt"
 	"math/rand"
 	"time"
+
+	"github.com/anishathalye/seashells-server/config"
+	"github.com/anishathalye/seashells-server/datamanager"
+	"github.com/caarlos0/env"
 )
 
-const baseUrl = "https://seashells.io/v/"
 const gcTime = 1 * 24 * time.Hour
 const dataLimit = 250 * 1024 // data limit in bytes
 const perUserLimit = 5
@@ -17,8 +20,21 @@ const pingPeriod = (pingTimeout * 9) / 10
 const maxMessageSize = 100
 
 func main() {
+
+	cfg := config.Config{}
+	if err := env.Parse(&cfg); err != nil {
+		fmt.Printf("failed to parse env vars: %v\n", err)
+		return
+	}
+
+	fmt.Printf("%+v\n", cfg)
+
 	rand.Seed(time.Now().UTC().UnixNano())
+
 	manager := datamanager.New(dataLimit, perUserLimit, gcTime)
+
 	go runNetcatServer(manager)
+
 	runWeb(manager)
+
 }


### PR DESCRIPTION
- feat: added  and expanded use of configuration environment variables
- chore: Updated README to document what the environment variables do and their defaults if not specified.
- chore: Updated README to show what ports/paths are used for what purposes

New base env vars:

```bash
#!/bin/bash
export BASE_URL='https://seashells.io/v/'
export WEBAPP_BINDING=':8080'
export NETCAT_BINDING=':1337'
export ADMIN_PASSWORD='xxx'
export GIN_MODE='debug'
export GTAG='g-tag'
```

I shared Seashells in [my newsletter today](https://dailyfinds.hrbrmstr.dev/p/drop-258-2023-05-10-browser-abuse) and wanted to shore the server code up a bit in the event some readers do try this at home.

Cool program!